### PR TITLE
Use the map instead of indexes when possible

### DIFF
--- a/dataset.js
+++ b/dataset.js
@@ -95,7 +95,7 @@ class Dataset extends N3Store {
   }
 
   toArray () {
-    return this._getQuads()
+    return Array.from(this._quads.values())
   }
 
   toStream () {

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -44,19 +44,7 @@ N3Store.prototype = {
 
   // ### `size` returns the number of quads in the store
   get size () {
-    // Calculate the number of quads by counting to the deepest level
-    let size = 0
-    const graphs = this._graphs
-    let subjects
-    let subject
-    for (const graphKey in graphs) {
-      for (const subjectKey in (subjects = graphs[graphKey].subjects)) {
-        for (const predicateKey in (subject = subjects[subjectKey])) {
-          size += Object.keys(subject[predicateKey]).length
-        }
-      }
-    }
-    return size
+    return this._quads.size
   },
 
   // ## Private methods
@@ -147,7 +135,6 @@ N3Store.prototype = {
                 [name2]: values[l]
               }
               const quad = this._quads.get(`${graph}:::${mapIndex.subject}::${mapIndex.predicate}::${mapIndex.object}`)
-              // console.warn(`get ${graph}:::${mapIndex.subject}::${mapIndex.predicate}::${mapIndex.object}`, quad)
               if (array) {
                 array.push(quad)
               } else if (iteratee(quad)) {
@@ -302,7 +289,6 @@ N3Store.prototype = {
     this.__addToIndex(graphItem.predicates, predicate, object, subject)
     this.__addToIndex(graphItem.objects, object, subject, predicate)
 
-    // console.warn(`set ${graph}:::${subject}::${predicate}::${object}`, originalQuad)
     this._quads.set(`${graph}:::${subject}::${predicate}::${object}`, quad)
 
     return changed

--- a/test/dataset.test.js
+++ b/test/dataset.test.js
@@ -20,7 +20,7 @@ function simpleFilter (subject, predicate, object, graph) {
   }
 }
 
-describe('SimpleDataset', () => {
+describe('Dataset', () => {
   test('should implement the Dataset interface', () => {
     const dataset = new Dataset()
 


### PR DESCRIPTION
Finally had time to come back to this.

This has dramatic effects on some dependencies, for instance https://github.com/rdf-ext/rdf-utils-dataset/blob/6039ad5edad37ac031c0423083239fbcdeedc9be/benchmark/resourcesToGraph.js

```diff
❯ node benchmark/resourcesToGraph.js
- resourcesToGraph: 3609.302ms
+ resourcesToGraph:  494.445ms
```