### PR TITLE
added method aliases for RDF/JS DatasetCore compatibility

### DIFF
--- a/dataset.js
+++ b/dataset.js
@@ -33,6 +33,10 @@ class Dataset extends N3Store {
     return this.create(this._getQuads())
   }
 
+  delete (quad) {
+    return this.remove(quad)
+  }
+
   difference (other) {
     return this.create(this.filter(quad => !other.includes(quad)))
   }
@@ -48,6 +52,10 @@ class Dataset extends N3Store {
 
   forEach (callback) {
     this._forEach(callback)
+  }
+
+  has (quad) {
+    return this.includes(quad)
   }
 
   import (stream) {
@@ -111,6 +119,10 @@ class Dataset extends N3Store {
     })
 
     return stream
+  }
+
+  [Symbol.iterator] () {
+    return this._quads.values()
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,24 @@
         "@types/rdf-js": "^2.0.1"
       }
     },
+    "@rdfjs/dataset": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.0.0.tgz",
+      "integrity": "sha512-7a7HOppFw1maEWQH1+muCjwuFdTDzYllzxROFCpcDiQE9dnCFkc9q6tAROamH/ezTP7jRuJjXFXLFpRjfx0xzw==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1"
+      }
+    },
+    "@rdfjs/namespace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-1.0.0.tgz",
+      "integrity": "sha512-/kGPf/Gug8Ah3GV5KZfBfpy+C/cw0bkVirxZ3JjxJfeRoMflUTEcv7gXShWx980zZhBdvzBIrTEtoqbE/VBHgQ==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.0"
+      }
+    },
     "@types/node": {
       "version": "10.12.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "lib"
   ],
   "devDependencies": {
+    "@rdfjs/dataset": "^1.0.0",
+    "@rdfjs/namespace": "^1.0.0",
     "babel-eslint": "^10.0.1",
     "coveralls": "^3.0.2",
     "eslint": "^5.12.1",

--- a/test/spec.test.js
+++ b/test/spec.test.js
@@ -1,0 +1,11 @@
+/* global describe */
+
+const model = require('@rdfjs/data-model')
+const dataset = require('..')
+const standard = require('@rdfjs/dataset/test')
+
+const rdf = Object.assign({ dataset }, model)
+
+describe('test suite', () => {
+  standard(rdf)
+})


### PR DESCRIPTION
Adds method aliases for [RDF/JS DatasetCore](https://rdf.js.org/dataset-spec/#datasetcore-interface) compatibility and test the interface using the tests from the [reference implementation](https://github.com/rdfjs/dataset).