### PR TITLE
Fix/empty language not datatype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* No longer return 'datatype' in toId() if literal is string or langString. 
+
 ## 0.4.0
 
 * Add method aliases for RDF/JS DatasetCore compatibility

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,6 +8,10 @@ const xsd = {
   string: 'http://www.w3.org/2001/XMLSchema#string'
 }
 
+const rdf = {
+  langString: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString'
+}
+
 const DEFAULTGRAPH = DataFactory.defaultGraph()
 
 // ### Constructs a term from the given internal string ID
@@ -57,10 +61,15 @@ function toId (term) {
     case 'Variable': return `?${term.value}`
     case 'DefaultGraph': return ''
     case 'Literal':
-      const datatype = term.datatype && term.datatype.value !== xsd.string ? `^^${term.datatype.value}` : ''
-      const language = term.language ? `@${term.language}` : datatype
+      const datatype =
+        term.datatype &&
+        term.datatype.value !== xsd.string &&
+        term.datatype.value !== rdf.langString
+          ? `^^${term.datatype.value}`
+          : ''
+      const language = term.language ? `@${term.language}` : ""
 
-      return `"${term.value}"${language}`
+      return `"${term.value}"${language}${datatype}`
     default: throw new Error(`Unexpected termType: ${term.termType}`)
   }
 }
@@ -68,5 +77,6 @@ function toId (term) {
 // ## Module exports
 module.exports = {
   fromId,
-  toId
+  toId,
+  DEFAULTGRAPH
 }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,64 @@
+const DataFactory = require('@rdfjs/data-model')
+
+const utils = require('../lib/utils')
+
+describe('utils', () => {
+  describe('fromId', () => {
+    test('variable', () => {
+      expect(utils.fromId('?var').value).toEqual('var')
+    })
+
+    test('literal', () => {
+      expect(utils.fromId('"var"').language).toEqual('')
+    })
+
+    test('literal with language', () => {
+      expect(utils.fromId('"var"@ga').language).toEqual('ga')
+    })
+
+    test('literal with datatype', () => {
+      expect(utils.fromId('"var"^^xsd:decimal').datatype.value).toEqual('xsd:decimal')
+    })
+  })
+
+  describe('toId', () => {
+    test('default graph', () => {
+      expect(utils.toId(false)).toEqual(utils.DEFAULTGRAPH.value)
+    })
+
+    test('variable', () => {
+      expect(utils.toId(DataFactory.variable('var'))).toEqual('?var')
+    })
+
+    test('unknown term type', () => {
+      const unknownType = "unknown type"
+      expect(() => utils.toId( {
+        termType: unknownType,
+        equals: function() { return false }
+      })).toThrow(unknownType)
+    })
+
+    test('term has ID', () => {
+      const termId = "some ID"
+      expect(utils.toId( {
+        id: termId,
+        equals: function() { return false }
+      })).toEqual(termId)
+    })
+
+    test('literal with language', () => {
+      const literal = DataFactory.literal('some text', 'ga')
+      expect(utils.toId(literal)).toEqual('"some text"@ga')
+    })
+
+    test('literal with no language', () => {
+      const literal = DataFactory.literal('some text')
+      expect(utils.toId(literal)).toEqual('"some text"')
+    })
+
+    test('literal with datatype', () => {
+      const literal = DataFactory.literal('some text', DataFactory.namedNode('https://custom-data-type.com/'))
+      expect(utils.toId(literal)).toEqual('"some text"^^https://custom-data-type.com/')
+    })
+  })
+})


### PR DESCRIPTION
This fixes a bug in 'toId()' when handling string literals of type `rdf:langString`.
Also adds tests to get coverage of `utils.js` up to 100%.
